### PR TITLE
Docs: Update link to Spinnaker.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Introduction**
 
-Spinnaker [\(http://www.spinnaker.io\)](https://qconsf.com/sf2017/workshop/%28http://www.spinnaker.io%29) is an open source, multi-cloud continuous delivery platform built by Netflix in partnership with Google, Microsoft, and others. At Netflix, Spinnaker powers over 4,000 deployments a day. With Spinnaker, you can easily automate complex delivery processes into repeatable pipelines that enable rapid deployments with confidence.
+Spinnaker [\(http://www.spinnaker.io\)](https://www.spinnaker.io) is an open source, multi-cloud continuous delivery platform built by Netflix in partnership with Google, Microsoft, and others. At Netflix, Spinnaker powers over 4,000 deployments a day. With Spinnaker, you can easily automate complex delivery processes into repeatable pipelines that enable rapid deployments with confidence.
 
 This workshop will provide hands-on experience building continuous delivery pipelines for deploying and promoting code across cloud virtual machines and containers. We’ll start with a git repository and work together in building repeatable pipelines that take code through packaging, deploying, promoting and rollbacks.
 


### PR DESCRIPTION
Old link is a 404